### PR TITLE
add items-image to Toppage

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
 
   def index
+    @items = Item.all.includes(:user).limit(4).order("created_at DESC")
   end
 
   def new

--- a/app/views/partial/_card.html.haml
+++ b/app/views/partial/_card.html.haml
@@ -1,10 +1,10 @@
 = link_to '#', class: 'card' do
   .card__photo
-    = image_tag 'common/sample_shoe.jpg', alt: '商品画像'
+    = image_tag item.images.first.name.url, alt: '商品画像'
   .card__body
-    %h3.card__body__head すごい靴
+    %h3.card__body__head= item.name
     .card__body__content
-      .card__body__content__price  ¥1,800
+      .card__body__content__price= "¥#{number_with_delimiter(item.price)}"
       .card__body__content__like
         %i.far.fa-heart
         %span 2

--- a/app/views/partial/_item-top.html.haml
+++ b/app/views/partial/_item-top.html.haml
@@ -2,9 +2,6 @@
   .item-top__head
     =link_to "新着アイテム", '#'
   .item-top__content
-    = render partial: 'partial/card'
-    = render partial: 'partial/card'
-    = render partial: 'partial/card'
-    = render partial: 'partial/card'
+    = render partial: 'partial/card', collection: @items, as: 'item'
   .item-top--all
     =link_to 'すべての商品を見る', '#'

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,11 +3,11 @@
 # category
 Category.create(name: 'レディース')
 Category.create(name: 'メンズ')
-Category.create(name: 'キッズ')
-Category.create(name: 'インテリア')
+Category.create(name: 'ベビー・キッズ')
+Category.create(name: 'コスメ・香水・美容')
 
 # size
-Size.create(name: 'S1')
+Size.create(name: 'S')
 Size.create(name: 'M')
 Size.create(name: 'L')
 Size.create(name: 'LL')


### PR DESCRIPTION
# What
add items-image to Toppage
https://gyazo.com/4a752d29b114ca19dfcc9314c5988b12

# Why
出品機能が追加されたため、トップページを修正した。
テストコードは作成後別のプルリクで出します。