### PR TITLE
edit

### DIFF
--- a/app/controllers/buys_controller.rb
+++ b/app/controllers/buys_controller.rb
@@ -1,15 +1,25 @@
 class BuysController < ApplicationController
   before_action :authenticate_user!, only: [ :index, :create]
   before_action :set_buys, only: [ :index, :create]
+  before_action :validation_seller_and_buyer_prevent_the_same, only: [:index, :create]
 
   def index
   end
 
   def create
     if @item.trade_status == 1
-      create_purchase_history(@item)
-      # 本家の購入確認後のページの確認ができないため仮置きでrootページを表示
-      redirect_to root_path
+      if @credit_card&.customer_id
+          Payjp.api_key = PAYJP_SECRET_KEY
+          customer_id =@credit_card.customer_id
+          Payjp::Charge.create(currency: 'jpy', amount: @item.price, customer: customer_id)
+          create_purchase_history(@item)
+          # 本家の購入確認後のページの確認ができないため仮置きでrootページを表示
+          redirect_to root_path
+      else
+          create_purchase_history(@item)
+          # 本家の購入確認後のページの確認ができないため仮置きでrootページを表示
+          redirect_to root_path
+      end
     else
       # 本家の購入確認後のページの確認ができないため仮置きで商品購入ページを再表示
       redirect_to item_buys_path
@@ -24,12 +34,19 @@ private
   def set_buys
     @item = Item.find(params[:item_id])
     @images = @item.images
+    @credit_card = CreditCard.find_by(user_id: current_user.id)
   end
 
   def create_purchase_history(item)
     partner = TradingPartner.where(seller_id: item.user_id, buyer_id: current_user.id).first_or_create
     Order.create(item_id: item.id, trading_partner_id: partner.id, status: 3)
     item.update(trade_status: 3)
+  end
+
+  def validation_seller_and_buyer_prevent_the_same
+    if current_user.id == @item.user_id
+      redirect_to new_user_session_path
+    end
   end
 
 end

--- a/app/controllers/buys_controller.rb
+++ b/app/controllers/buys_controller.rb
@@ -12,14 +12,10 @@ class BuysController < ApplicationController
           Payjp.api_key = PAYJP_SECRET_KEY
           customer_id =@credit_card.customer_id
           Payjp::Charge.create(currency: 'jpy', amount: @item.price, customer: customer_id)
-          create_purchase_history(@item)
-          # 本家の購入確認後のページの確認ができないため仮置きでrootページを表示
-          redirect_to root_path
-      else
-          create_purchase_history(@item)
-          # 本家の購入確認後のページの確認ができないため仮置きでrootページを表示
-          redirect_to root_path
       end
+      create_purchase_history(@item)
+      # 本家の購入確認後のページの確認ができないため仮置きでrootページを表示
+      redirect_to root_path
     else
       # 本家の購入確認後のページの確認ができないため仮置きで商品購入ページを再表示
       redirect_to item_buys_path


### PR DESCRIPTION
# WHAT
・Pay.jpで決済ができるようにcreateアクション編集
・出品者と購入者が同じ場合直接pathで購入ページを表示せず、rootページを表示するようにbefor_action定義

クレジットカード sql
[![Image from Gyazo](https://i.gyazo.com/c890a40c470243892e28ed5e08a3a04d.png)]

gif View 
[![Image from Gyazo](https://i.gyazo.com/b212e8dda2d8e08132dde44731dc3c7a.gif)] 

payjp
[![Image from Gyazo](https://i.gyazo.com/8e561de5fbe2796a933212c46a52cf1f.png)] 

# WHY 
・APIで決済情報管理することによるセキュリティ強化
・pathで出品者が自分の商品を購入できないようにするため